### PR TITLE
Add ability to run the Hub locally for development

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '3.4'
 services:
   proxy:
     image: ${DOCKER_REGISTRY_URI}/${DOCKER_IMAGE_NAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '3.4'
 services:
   proxy:
     build:


### PR DESCRIPTION
This is part of a Hub-wide feature to run the complete Hub locally for development. The changes in this repository will enable the proxy to run locally.

The feature will be progressively merged into different repositories. See the deploy project pull request for more information.