### PR TITLE
Change shibboleth library name to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE      80 443
 
 # Install dependencies
 RUN         apt-get update && apt-get install -y \
-		        libapache2-mod-shib2 \
+		        libapache2-mod-shib \
 		        vim \
 		        curl \
                 gettext-base

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                    docker-compose                        \\
                      -f docker-compose.yml               \\
                      -f docker-compose.ci.yml            \\
-                     build --no-cache proxy
+                     build --no-cache --pull proxy
                    '''
             }
           

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                    docker-compose                        \\
                      -f docker-compose.yml               \\
                      -f docker-compose.ci.yml            \\
-                     build proxy
+                     build --no-cache proxy
                    '''
             }
           

--- a/conf.d/modules.conf
+++ b/conf.d/modules.conf
@@ -1,7 +1,7 @@
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule ssl_module modules/mod_ssl.so
 LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
-LoadModule mod_shib /usr/lib/apache2/modules/mod_shib2.so
+LoadModule mod_shib /usr/lib/apache2/modules/mod_shib.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_ajp_module modules/mod_proxy_ajp.so


### PR DESCRIPTION
We discovered the proxy Docker image gives an error when running hubby-local up:
`proxy_1    | httpd: Syntax error on line 194 of /usr/local/apache2/conf/httpd.conf: Syntax error on line 4 of /usr/local/apache2/conf/conf.d/modules.conf: Cannot load /usr/lib/apache2/modules/mod_shib2.so into server: /usr/lib/apache2/modules/mod_shib2.so: cannot open shared object file: No such file or directory`
After investigating, the problem seems to come from the fact that the `httpd` Docker image, which this Docker image uses as the base image, has moved the the mod_shib library file to /usr/lib/apache2/modules/mod_shib.so. We will update references to this file in order to fix the build.